### PR TITLE
Automatically choose between American and British spelling

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -78,7 +78,7 @@
                   <option value="fileSelectBtn">Use an image from your device</option>
                   <option value="imageUrlForm">Use an image from URL</option>
                   <option value="openVideoModalBtn">Take photo with webcam</option>
-                  <option value="solidColorForm">Use solid color</option>
+                  <option value="solidColorForm" id="solidColorOption">Use solid color</option>
                 </select>
               </div>
 
@@ -218,7 +218,7 @@
 
               <form id="solidColorForm" class="upload-method row g-2" hidden>
                 <div class="col-4">
-                  <label for="canvasColor">Color:</label>
+                  <label for="canvasColor" id="colorFormLabel">Color:</label>
                   <input type="color" name="canvasColor" id="canvasColor" class="form-control" value="#ffffff" style="height: 33.5px;">
                 </div>
                 <div class="col-4">
@@ -275,7 +275,7 @@
 
       <div class="row mb-5">
         <div class="col text-center">
-          Licensed under <a class="text-underline" href="https://github.com/georapbox/meme-generator/blob/master/LICENSE" target="_blank" rel="noopener">The MIT License (MIT)</a>
+          Licensed under <a class="text-underline" href="https://github.com/georapbox/meme-generator/blob/master/LICENSE" target="_blank" rel="noopener" id="licenseText">The MIT License (MIT)</a>
         </div>
       </div>
     </div>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -759,3 +759,55 @@ function changesHaveOccurred() {
 
   return hasChanges;
 }
+
+
+// Change the spelling depending on your browser's language settings
+const spellings = {
+  color: {
+    "en-US": "color",
+    "en-GB": "colour",
+    "en-CA": "colour",
+    "en-AU": "colour",
+    default: "color"
+  },
+  license: {
+    "en-US": "license",
+    "en-GB": "licence",
+    "en-CA": "license",
+    "en-AU": "licence",
+    default: "license"
+  }
+}
+/* NOTES ABOUT THE WORD "LICENSE":
+  Only apply this to the noun. The verb is always spelled "license".
+  Both are acceptable in Canadian English.
+*/
+
+// The below code was written by ChatGPT.
+function getSpelling(wordKey) {
+  const variants = spellings[wordKey];
+  if (!variants) return wordKey;
+
+  const languages = navigator.languages || [navigator.language];
+
+  for (const lang of languages) {
+    // exact locale match
+    if (variants[lang]) {
+      return variants[lang];
+    }
+
+    // language-only fallback (for example en-NZ → any en-* entry)
+    const base = lang.split("-")[0];
+
+    for (const locale in variants) {
+      if (locale.startsWith(base + "-")) {
+        return variants[locale];
+      }
+    }
+  }
+
+  return variants.default || wordKey;
+}
+
+// End of AI-generated code.
+// To use it, just run `getSpelling("color")` (with the word you want) and it will be replaced with the correct spelling.

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -785,29 +785,53 @@ const spellings = {
 
 // The below code was written by ChatGPT.
 function getSpelling(wordKey) {
-  const variants = spellings[wordKey];
+  const lookupKey = wordKey.toLowerCase();
+  const variants = spellings[lookupKey];
   if (!variants) return wordKey;
 
   const languages = navigator.languages || [navigator.language];
+  let result = variants.default || lookupKey;
 
   for (const lang of languages) {
-    // exact locale match
     if (variants[lang]) {
-      return variants[lang];
+      result = variants[lang];
+      break;
     }
 
-    // language-only fallback (for example en-NZ → any en-* entry)
     const base = lang.split("-")[0];
 
     for (const locale in variants) {
       if (locale.startsWith(base + "-")) {
-        return variants[locale];
+        result = variants[locale];
+        break;
       }
     }
   }
 
-  return variants.default || wordKey;
-}
+  // preserve capitalization style
+  if (wordKey === wordKey.toUpperCase()) {
+    return result.toUpperCase();          // COLOR -> COLOUR
+  }
 
+  if (wordKey[0] === wordKey[0].toUpperCase()) {
+    return result.charAt(0).toUpperCase() + result.slice(1); // Color -> Colour
+  }
+
+  return result;                          // color -> colour
+}
 // End of AI-generated code.
 // To use it, just run `getSpelling("color")` (with the word you want) and it will be replaced with the correct spelling.
+// It's supposed to keep the capitalization of the input text.
+
+
+// Automatically replace words with the correct spelling
+
+// The "use solid color" option in the image source dropdown
+document.getElementById("solidColorOption").textContent = `Use solid ${getSpelling("color")}`;
+
+// The "color" label in solidColorForm
+document.getElementById("colorFormLabel").textContent = `${getSpelling("Color")}:`;
+
+// The MIT license text at the bottom of the page
+document.getElementById("licenseText").textContent = `The MIT ${getSpelling("License")}`;
+


### PR DESCRIPTION
I added some code to automatically choose between the American and British spelling for color/colour and license/licence.
Part of the code was written by ChatGPT. I haven't tested anything, so I don't know if it will work. Please test it for me (I don't have admin access so I can't install the required software).